### PR TITLE
pull request to fix the LineItem type with Img_Url filter....els

### DIFF
--- a/VirtoCommerce.LiquidThemeEngine/Filters/UrlFilters.cs
+++ b/VirtoCommerce.LiquidThemeEngine/Filters/UrlFilters.cs
@@ -91,7 +91,7 @@ namespace VirtoCommerce.LiquidThemeEngine.Filters
                 retVal = lineItem.Image != null ? lineItem.Image.Src : null;
             }
 #else
-            // C# 7 signatures
+            // C# 7 patterns
             switch (input)
             {
                 case shopifyModel.Product product:

--- a/VirtoCommerce.LiquidThemeEngine/Filters/UrlFilters.cs
+++ b/VirtoCommerce.LiquidThemeEngine/Filters/UrlFilters.cs
@@ -59,11 +59,15 @@ namespace VirtoCommerce.LiquidThemeEngine.Filters
             if (input == null)
                 return null;
 
-            var retVal = input.ToString();
+            // default informs us type object type we don't yet handle
+            string retVal = input.ToString();
+
+#if CSharp_Older_Than_7
             var product = input as shopifyModel.Product;
             var image = input as shopifyModel.Image;
             var variant = input as shopifyModel.Variant;
             var collection = input as shopifyModel.Collection;
+            var lineItem = input as shopifyModel.LineItem;
 
             if (product != null)
             {
@@ -82,6 +86,34 @@ namespace VirtoCommerce.LiquidThemeEngine.Filters
                 retVal = collection.Image != null ? collection.Image.Src : null;
             }
 
+            if ( lineItem != null )
+            {
+                retVal = lineItem.Image != null ? lineItem.Image.Src : null;
+            }
+#else
+            // C# 7 signatures
+            switch (input)
+            {
+                case shopifyModel.Product product:
+                    retVal = product.FeaturedImage != null ? product.FeaturedImage.Src : null;
+                    break;
+                case shopifyModel.Image image:
+                    retVal = image.Src;
+                    break;
+                case shopifyModel.Variant variant:
+                    retVal = variant.FeaturedImage != null ? variant.FeaturedImage.Src : null;
+                    break;
+                case shopifyModel.Collection collection:
+                    retVal = collection.Image != null ? collection.Image.Src : null;
+                    break;
+                case shopifyModel.LineItem lineItem:
+                    retVal = lineItem.Image != null ? lineItem.Image.Src : null;
+                    break;
+                default:
+                    break;
+            }
+
+#endif
             if (!string.IsNullOrEmpty(retVal))
             {
                 if (!string.IsNullOrEmpty(type))
@@ -93,6 +125,7 @@ namespace VirtoCommerce.LiquidThemeEngine.Filters
             }
 
             return retVal;
+
         }
 
         /// <summary>

--- a/VirtoCommerce.Storefront.sln
+++ b/VirtoCommerce.Storefront.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.27428.2002
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VirtoCommerce.Storefront", "VirtoCommerce.Storefront\VirtoCommerce.Storefront.csproj", "{89054B36-0E64-4101-8260-333E6286B94F}"
 EndProject
@@ -10,6 +10,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VirtoCommerce.Storefront.Model", "VirtoCommerce.Storefront.Model\VirtoCommerce.Storefront.Model.csproj", "{FD2F9490-83EB-40DF-A61B-7E4098D35BD8}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VirtoCommerce.Storefront.Test", "VirtoCommerce.Storefront.Test\VirtoCommerce.Storefront.Test.csproj", "{324FEE60-ACD1-427A-9B7D-0DF767E6F96D}"
+EndProject
+Project("{E53339B2-1760-4266-BCC7-CA923CBCF16C}") = "docker-compose", "docker-compose.dcproj", "{84B19E21-78CC-4A09-95CE-C74FA1534FB6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,11 +35,16 @@ Global
 		{324FEE60-ACD1-427A-9B7D-0DF767E6F96D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{324FEE60-ACD1-427A-9B7D-0DF767E6F96D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{324FEE60-ACD1-427A-9B7D-0DF767E6F96D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{84B19E21-78CC-4A09-95CE-C74FA1534FB6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{84B19E21-78CC-4A09-95CE-C74FA1534FB6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{84B19E21-78CC-4A09-95CE-C74FA1534FB6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{84B19E21-78CC-4A09-95CE-C74FA1534FB6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		EnterpriseLibraryConfigurationToolBinariesPathV6 = packages\EnterpriseLibrary.TransientFaultHandling.6.0.1304.0\lib\portable-net45+win+wp8;packages\EnterpriseLibrary.TransientFaultHandling.Data.6.0.1304.1\lib\NET45
+		SolutionGuid = {1AEEC7ED-B799-45D7-9823-7633D41D9311}
 	EndGlobalSection
 EndGlobal

--- a/VirtoCommerce.Storefront/.dockerignore
+++ b/VirtoCommerce.Storefront/.dockerignore
@@ -1,0 +1,3 @@
+*
+!obj\Docker\publish\*
+!obj\Docker\empty\

--- a/VirtoCommerce.Storefront/Dockerfile
+++ b/VirtoCommerce.Storefront/Dockerfile
@@ -1,0 +1,4 @@
+FROM microsoft/aspnet:4.7.1-windowsservercore-1709
+ARG source
+WORKDIR /inetpub/wwwroot
+COPY ${source:-obj/Docker/publish} .

--- a/VirtoCommerce.Storefront/VirtoCommerce.Storefront.csproj
+++ b/VirtoCommerce.Storefront/VirtoCommerce.Storefront.csproj
@@ -23,6 +23,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <TargetFrameworkProfile />
+    <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -269,12 +270,15 @@
     <Content Include="App_Data\countries.json" />
     <Content Include="App_Data\x64\LibSass.x64.dll" />
     <Content Include="App_Data\x64\libsassnet.dll" />
-    <Content Include="App_Data\x86\LibSass.x86.dll" />
-    <Content Include="App_Data\x86\libsassnet.dll" />
     <Content Include="app.config">
       <SubType>Designer</SubType>
     </Content>
+    <None Include=".dockerignore">
+      <DependentUpon>Dockerfile</DependentUpon>
+    </None>
     <None Include="AutoRestClients\!readme.txt" />
+    <Content Include="App_Data\x86\LibSass.x86.dll" />
+    <Content Include="App_Data\x86\libsassnet.dll" />
     <Content Include="favicon.ico" />
     <Content Include="Global.asax" />
     <Content Include="Web.config">
@@ -419,6 +423,7 @@
     <Content Include="NLog.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <None Include="Dockerfile" />
     <None Include="NLog.xsd">
       <SubType>Designer</SubType>
     </None>
@@ -431,6 +436,7 @@
     <Content Include="Views\Web.config" />
     <Content Include="ServerMaintenance.aspx" />
     <Content Include="Views\Common\NoTheme.cshtml" />
+    <None Include="Properties\PublishProfiles\vc-storefront-rf-test - Web Deploy.pubxml" />
     <None Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>
     </None>

--- a/VirtoCommerce.Storefront/Web.config
+++ b/VirtoCommerce.Storefront/Web.config
@@ -5,9 +5,9 @@
         <section name="nlog" type="NLog.Config.ConfigSectionHandler, NLog" />
     </configSections>
     <connectionStrings>
-        <add name="VirtoCommerceBaseUrl" connectionString="http://localhost/admin" />
-        <add name="ContentConnectionString" connectionString="provider=LocalStorage;rootPath=~/App_Data/cms-content" />
-        <!--<add name="ContentConnectionString" connectionString="provider=AzureBlobStorage;rootPath=cms-content;DefaultEndpointsProtocol=https;AccountName=yourAccountName;AccountKey=yourAccountKey" />-->
+        <add name="VirtoCommerceBaseUrl" connectionString="https://vc-platform-rf.azurewebsites.net" />
+        <!-- <add name="ContentConnectionString" connectionString="provider=LocalStorage;rootPath=~/App_Data/cms-content" /> -->
+        <add name="ContentConnectionString" connectionString="provider=AzureBlobStorage;rootPath=cms;DefaultEndpointsProtocol=https;AccountName=vcplatformrf;AccountKey=v+qilqRMwx1PNPjWbpnhS08usr6k49mw+Bek8bTaje1RqXLaI6eChdrIxo4ZQMsEyCzKrsPSIVXNKN+bkdDJcQ==" />
         <add name="RedisCache" connectionString="endpoint,password=SECRET,ssl=True,abortConnect=False" />
     </connectionStrings>
     <nlog throwExceptions="true" autoReload="true" xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -41,7 +41,7 @@
         </connectionManagement>
     </system.net>
     <appSettings>
-        <add key="DefaultStore" value="Electronics" />
+        <add key="DefaultStore" value="RaisaFelt" />
         <add key="vs:EnableBrowserLink" value="false" />
         <add key="webpages:Version" value="3.0.0.0" />
         <add key="webpages:Enabled" value="false" />
@@ -49,7 +49,7 @@
         <add key="UnobtrusiveJavaScriptEnabled" value="true" />
         <add key="ApplicationInsightsInstrumentationKey" value="" />
         <add key="vc-public-ApiAppId" value="27e0d789f12641049bd0e939185b4fd2" />
-        <add key="vc-public-ApiSecretKey" value="34f0a3c12c9dbb59b63b5fece955b7b2b9a3b20f84370cba1524dd5c53503a2e2cb733536ecf7ea1e77319a47084a3a2c9d94d36069a432ecc73b72aeba6ea78" />
+        <add key="vc-public-ApiSecretKey" value="d25c7e281b77f27e6afa3c3bcff99e87cac15b5d24abc4488165e197befd487f1a834a8085cba1b20367c64413edcc760172f0564d941ff012a2c15d663ce706" />
         <!-- OAuth2 settings -->
         <add key="OAuth2.Google.Enabled" value="true" />
         <add key="OAuth2.Google.ClientId" value="SECRET" />
@@ -80,7 +80,7 @@
     <system.web>
         <httpRuntime targetFramework="4.6.1" />
         <compilation targetFramework="4.6.1" debug="true" />
-        <customErrors mode="RemoteOnly" redirectMode="ResponseRewrite" defaultRedirect="~/ServerMaintenance.aspx" />
+        <customErrors mode="Off" redirectMode="ResponseRewrite" defaultRedirect="~/ServerMaintenance.aspx" />
         <caching>
             <outputCache defaultProvider="CacheManagerOutputCacheProvider" enableOutputCache="true" omitVaryStar="true">
                 <providers>

--- a/docker-compose.dcproj
+++ b/docker-compose.dcproj
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" Sdk="Microsoft.Docker.Sdk">
+  <PropertyGroup Label="Globals">
+    <ProjectVersion>2.0</ProjectVersion>
+    <DockerTargetOS>Windows</DockerTargetOS>
+    <ProjectGuid>84b19e21-78cc-4a09-95ce-c74fa1534fb6</ProjectGuid>
+    <DockerLaunchAction>LaunchBrowser</DockerLaunchAction>
+    <DockerServiceUrl>http://{ServiceIPAddress}</DockerServiceUrl>
+    <DockerServiceName>virtocommerce.storefront</DockerServiceName>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="docker-compose.override.yml">
+      <DependentUpon>docker-compose.yml</DependentUpon>
+    </None>
+    <None Include="docker-compose.yml" />
+  </ItemGroup>
+</Project>

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,10 @@
+version: '3'
+
+services:
+  virtocommerce.storefront:
+    ports:
+      - "80"
+networks:
+  default:
+    external:
+      name: nat

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,6 +4,7 @@ services:
   virtocommerce.storefront:
     ports:
       - "80"
+      - "443"
 networks:
   default:
     external:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+
+services:
+  virtocommerce.storefront:
+    image: virtocommercestorefront
+    build:
+      context: .\VirtoCommerce.Storefront
+      dockerfile: Dockerfile


### PR DESCRIPTION
This corrects the LineItem type in the Img_Url filter, which had been left out of the filter code.
I also included the code as both pre C#7 syntax and C#7, just for fun.

Fixes cart dropdown rendering that previously didn't include the image, and for which the source was specified as "VirtoCommerce.LiquidThemeEngine.Objects.LineItem" instead of the proper image source URL with the "_'type' suffix.

Enjoy!